### PR TITLE
Fix scanning with border

### DIFF
--- a/src/main/java/io/github/brendoncurmi/fxbiomertp/impl/SpiralScan.java
+++ b/src/main/java/io/github/brendoncurmi/fxbiomertp/impl/SpiralScan.java
@@ -84,7 +84,9 @@ public class SpiralScan {
      */
     public void startScan() {
         WorldBorder border = world.getWorldBorder();
-        int xy = Math.min(MAX_BLOCKS_XY, (int) ((border.getDiameter() - 1) / 2));
+        int xy = Math.min(MAX_BLOCKS_XY, (int) border.getDiameter()) / CHUNK_SIZE;
+        xy -= 2;// Remove 2 chunks to have enough distance from the world border
+        if (xy < 0) xy = 0;
         startScan(xy, xy, 0, 0);
     }
 


### PR DESCRIPTION
Scan area is half it's size with the border and sometimes goes outside
the border. Make it so that it encompasses a correct amount of space
within the border and doesnt expand beyond it